### PR TITLE
Fix cross compile and boost

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,8 @@
 - Added ARM support for daemon and QT
 - Fixed overwrite effect on splash when loading a theme
 - Rotate dynamically the splash for long stuff, like index rebuild or bootstrap import
+- Cross compile for Fedora 29 and Fedora 30
+- Fixed compatibilty with BOOST >= 1.66
 
 
 ***** Version 3.3.2.13 (DEV version, preparing for 4.0.0.1)

--- a/litecoinplus.pro
+++ b/litecoinplus.pro
@@ -1,8 +1,8 @@
 TEMPLATE = app
 TARGET = litecoinplus-qt
 VERSION = 2.0.1
-INCLUDEPATH += src src/json src/qt
-DEFINES += QT_GUI BOOST_THREAD_USE_LIB BOOST_SPIRIT_THREADSAFE
+INCLUDEPATH += src src/json src/qt /usr/include/libdb4
+DEFINES += QT_GUI BOOST_THREAD_USE_LIB BOOST_SPIRIT_THREADSAFE BOOST_ASIO_ENABLE_OLD_SERVICES
 CONFIG += no_include_pwd
 CONFIG += thread
 QT += network

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -771,7 +771,13 @@ void ThreadRPCServer2(void* parg)
 
     asio::io_service io_service;
 
-    ssl::context context(io_service, ssl::context::sslv23);
+    // BOOST 1.66 require old asio interface and syntax is different too
+#if BOOST_VERSION >= 106600L
+	ssl::context context(ssl::context::sslv23);
+#else
+	ssl::context context(io_service, ssl::context::sslv23);
+#endif
+
     if (fUseSSL)
     {
         context.set_options(ssl::context::no_sslv2);
@@ -787,7 +793,7 @@ void ThreadRPCServer2(void* parg)
         else printf("ThreadRPCServer ERROR: missing server private key file %s\n", pathPKFile.string().c_str());
 
         string strCiphers = GetArg("-rpcsslciphers", "TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!AH:!3DES:@STRENGTH");
-        SSL_CTX_set_cipher_list(context.impl(), strCiphers.c_str());
+        SSL_CTX_set_cipher_list(context.native_handle(), strCiphers.c_str());
     }
 
     // Try a dual IPv6/IPv4 socket, falling back to separate IPv4 and IPv6 sockets
@@ -1081,7 +1087,14 @@ Object CallRPC(const string& strMethod, const Array& params)
     // Connect to localhost
     bool fUseSSL = GetBoolArg("-rpcssl");
     asio::io_service io_service;
-    ssl::context context(io_service, ssl::context::sslv23);
+
+    // BOOST 1.66 require old asio interface and syntax is different too
+#if BOOST_VERSION >= 106600L
+	ssl::context context(ssl::context::sslv23);
+#else
+	ssl::context context(io_service, ssl::context::sslv23);
+#endif
+
     context.set_options(ssl::context::no_sslv2);
     asio::ssl::stream<asio::ip::tcp::socket> sslStream(io_service, context);
     SSLIOStreamDevice<asio::ip::tcp> d(sslStream, fUseSSL);


### PR DESCRIPTION
Cross compile for Fedora 29/30
Boost >= 1.66 can now fully compile